### PR TITLE
reschedule fetcher despite potential error

### DIFF
--- a/fetcher.js
+++ b/fetcher.js
@@ -83,8 +83,8 @@ var Fetcher = function(listID, reloadInterval, accessToken) {
                     // });
 
                     self.broadcastItems();
-                    scheduleTimer();
                 }
+                scheduleTimer();
             });
 
     };


### PR DESCRIPTION
When the update of the list was not successful, e.g. when there is a network failure, the update is not rescheduled and never updates again. This is fixed with this PR.