### PR TITLE
Adding support for labels

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -71,7 +71,8 @@ Module.register("MMM-Todoist", {
 	getTranslations: function () {
 		return {
 			en: "translations/en.json",
-			de: "translations/de.json"
+			de: "translations/de.json",
+			nb: "translations/nb.json"
 		};
 	},
 

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -10,18 +10,20 @@
 
 
 /*
+ * Update by mabahj 24/11/2019
+ * - Added support for labels in addtion to projects
  * Update by AgP42 the 18/07/2018
- * Modification added : 
- * - Management of a PIR sensor with the module MMM-PIR-Sensor (by PaViRo). In case PIR module detect no user, 
+ * Modification added :
+ * - Management of a PIR sensor with the module MMM-PIR-Sensor (by PaViRo). In case PIR module detect no user,
  * the update of the ToDoIst is stopped and will be requested again at the return of the user
  * - Management of the "module.hidden" by the core system : same behaviour as "User_Presence" by the PIR sensor
  * - Add "Loading..." display when the infos are not yet loaded from the server
- * - Possibility to add the last update time from server at the end of the module. 
+ * - Possibility to add the last update time from server at the end of the module.
  * This can be configured using "displayLastUpdate" and "displayLastUpdateFormat"
  * - Possibility to display long task on several lines(using the code from default module "calendar".
  * This can be configured using "wrapEvents" and "maxTitleLength"
  *
- * // Update 27/07/2018 : 
+ * // Update 27/07/2018 :
  * - Correction of start-up update bug
  * - correction of regression on commit #28 for tasks without dueDate
  * */
@@ -34,6 +36,7 @@ Module.register("MMM-Todoist", {
 	defaults: {
 		maximumEntries: 10,
 		projects: ["inbox"],
+    labels: [""],
 		updateInterval: 10 * 60 * 1000, // every 10 minutes,
 		fade: true,
 		fadePoint: 0.25,
@@ -57,7 +60,7 @@ Module.register("MMM-Todoist", {
 		apiVersion: "v8",
 		apiBase: "https://todoist.com/API",
 		todoistEndpoint: "sync",
-		todoistResourceType: "[\"items\", \"projects\"]",
+		todoistResourceType: "[\"items\", \"projects\", \"labels\"]",
 		debug: false,
 	},
 
@@ -211,6 +214,7 @@ Module.register("MMM-Todoist", {
 	filterTodoistData: function (tasks) {
 		var self = this;
 		var items = [];
+    var labelIds = [];
 
 
 		if (tasks == undefined) {
@@ -222,6 +226,19 @@ Module.register("MMM-Todoist", {
 		if (tasks.items == undefined) {
 			return;
 		}
+    
+    // Loop through labels fetched from API and find corresponding label IDs for task filtering
+    // Could be re-used for project names -> project IDs.
+    if (self.config.labels.length>0 && tasks.labels != undefined) {
+      for (let apiLabel of tasks.labels) {
+        for (let configLabelName of self.config.labels) {
+          if (apiLabel.name == configLabelName) {
+            labelIds.push(apiLabel.id);
+            break;
+          }
+        }
+      }
+    }
 
 		if (self.config.displayTasksWithinDays > -1 || !self.config.displayTasksWithoutDue) {
 			tasks.items = tasks.items.filter(function (item) {
@@ -239,13 +256,34 @@ Module.register("MMM-Todoist", {
 			});
 		}
 
-		//Filter the Todos by the Projects specified in the Config
-		tasks.items.forEach(function (item) {
-			self.config.projects.forEach(function (project) {
-				if (item.project_id == project) {
-					items.push(item);
-				}
-			});
+		//Filter the Todos by the Projects and Label specified in the Config
+		tasks.items.forEach(function (item) {      
+
+      var isAdded=0; // To prevent a task in added twice. Far from fancy, can be improved. But it works.
+
+      // Filter using label if a label is configured
+      if (labelIds.length>0 && item.labels.length > 0) {
+        // Check all the labels assigned to the task. Add to items if match with configured label
+        for (let label of item.labels) {
+          for (let labelNumber of labelIds) {
+            if (label == labelNumber && isAdded==0) {
+              items.push(item);
+              isAdded=1; // Prevent double additions
+              break;
+            }
+          }
+        }
+      }
+
+      // Filter using projets if projects are configured
+      if (isAdded==0 && self.config.projects.length>0){
+			  self.config.projects.forEach(function (project) {
+			  	if (item.project_id == project) {
+            items.push(item);
+			  	}
+			  });
+      }
+
 		});
 
 		//Used for ordering by date
@@ -448,7 +486,7 @@ Module.register("MMM-Todoist", {
 				projectCell.className = "xsmall";
 				projectCell.innerHTML = project.name + "<span class='projectcolor' style='color: " + projectcolor + "; background-color: " + projectcolor + "'></span>";
 				row.appendChild(projectCell);
-			} 
+			}
 
 
 			// Create fade effect by MichMich (MIT)

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ modules: [
 		position: 'top_right',	// This can be any of the regions. Best results in left or right regions.
 		header: 'Todoist', // This is optional
 		config: { // See 'Configuration options' for more information.
-          	accessToken: 'accessToken from Todoist',
+			accessToken: 'accessToken from Todoist',
 			maximumEntries: 60,
 			updateInterval: 10*60*1000, // Update every 10 minutes
 			fade: false,      
 			// projects and/or labels is mandatory:
-      projects: [ 166564794 ], 
+			projects: [ 166564794 ], 
 			labels: [ "MagicMirror", "Important" ] // Tasks for any projects with these labels will be shown.
       }
 	}

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ modules: [
           	accessToken: 'accessToken from Todoist',
 			maximumEntries: 60,
 			updateInterval: 10*60*1000, // Update every 10 minutes
-			projects: [ 166564794 ], //this entry or labels is mandatory
-            labels: [ "MagicMirror", "Important" ], // Tasks for any projects with these labels will be shown.
-			fade: false
+			fade: false,      
+			// projects and/or labels is mandatory:
+      projects: [ 166564794 ], 
+			labels: [ "MagicMirror", "Important" ] // Tasks for any projects with these labels will be shown.
       }
 	}
 ]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following properties can be configured:
 				<br><b>Example:</b> <code>["MagicMirror", "Important", "DoInTheMorning"]</code>
 				<br>
 				<br>
-				<b>This value and/or the labels entry must be specified</b>. If both projects and labels are specified, then tasks from both will be shown.
+				<b>This value and/or the projects entry must be specified</b>. If both projects and labels are specified, then tasks from both will be shown.
 			</td>
 		</tr>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # MMM-Todoist
 This an extension for the [MagicMirror](https://github.com/MichMich/MagicMirror). It can display your Todoist todos. You can add multiple instances with different lists. Only one account supported.
 The requests to the server will be paused is the module is not displayed (use of a carousel or hidden by Remote-Control for example) or by the use of a PIR sensor and the module MMM-PIR-Sensor. An immediate update will occurs at the return of the module display. 
@@ -19,7 +20,8 @@ modules: [
           	accessToken: 'accessToken from Todoist',
 			maximumEntries: 60,
 			updateInterval: 10*60*1000, // Update every 10 minutes
-			projects: [ 166564794 ], //this entry is mandatory
+			projects: [ 166564794 ], //this entry or labels is mandatory
+            labels: [ "MagicMirror", "Important" ], // Tasks for any projects with these labels will be shown.
 			fade: false
       }
 	}
@@ -61,8 +63,20 @@ The following properties can be configured:
 				1) Go to Todoist (Log in if you aren't)<br>
 				2) Click on a Project in the left menu<br>
 				3) Your browser URL will change to something like<br> <code>"https://todoist.com/app?lang=en&v=818#project%2F166564897"</code><br><br>
-				Everything after %2F is the Project ID. In this case "166564897"
-				<b>This value is mandatory</b>.
+				Everything after %2F is the Project ID. In this case "166564897"<br><br>
+				<b>This value and/or the labels entry must be specified</b>. If both projects and labels are specified, then tasks from both will be shown.
+			</td>
+		</tr>
+			<tr>
+			<td><code>labels</code></td>
+			<td>
+				Array of label names you want to display. <br>
+				<br><b>Possible values:</b> <code>array</code>
+				<br><b>Default value:</b> <code>[ ]</code>
+				<br><b>Example:</b> <code>["MagicMirror", "Important", "DoInTheMorning"]</code>
+				<br>
+				<br>
+				<b>This value and/or the labels entry must be specified</b>. If both projects and labels are specified, then tasks from both will be shown.
 			</td>
 		</tr>
 		<tr>

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -1,0 +1,15 @@
+{
+	"YESTERDAY": "I går",
+	"JAN": "Jan",
+	"FEB": "Feb",
+    "MAR": "Mar",
+    "APR": "Apr",
+    "MAY": "Mai",
+    "JUN": "Jun",
+    "JUL": "Jul",
+    "AUG": "Aug",
+    "SEP": "Sep",
+    "OCT": "Okt",
+    "NOV": "Nov",
+    "DEC": "Des"
+}


### PR DESCRIPTION
Hi,
I've added support for labels in my fork. I did this because it for me makes more sense to add a label to tasks from whatever project, if I want those tasks shown on MM.  Since I've forked and also use your work (thanks!) , then I'd like to share it back as a PR in case you find it valuable.

It supports labels (zero or one or many) in addition to projects. It uses the label names, so no need to manually find label IDs or something. That part of the code can probably be re-used to support project names instead of IDs, if you want. 

Note that I do not have a lot of experience with JS, so there could be issues, such as errors not being caught as they should. But I've tested several configuration options and it seems to work just fine. 

So you could have a look at determine if it looks good and if you want to pull it in. (Or edit and then pull in, feel free.)

(I also added Norwegian translation, since I had it open.)