### PR TITLE
Use value of displaySubtasks

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -262,6 +262,9 @@ Module.register("MMM-Todoist", {
 		tasks.items.forEach(function (item) {
 			var isAdded=0; // To prevent a task in added twice. Far from fancy, can be improved. But it works.
 
+			// Ignore sub-tasks
+			if (item.parent_id!=null && !self.config.displaySubtasks) { return; }
+
 			// Filter using label if a label is configured
 			if (labelIds.length>0 && item.labels.length > 0) {
 				// Check all the labels assigned to the task. Add to items if match with configured label

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -258,7 +258,7 @@ Module.register("MMM-Todoist", {
 			});
 		}
 
-		//Filter the Todos by the Projects and Label specified in the Config
+		//Filter the Todos by the criteria specified in the Config
 		tasks.items.forEach(function (item) {
 			// Ignore sub-tasks
 			if (item.parent_id!=null && !self.config.displaySubtasks) { return; }

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -260,8 +260,6 @@ Module.register("MMM-Todoist", {
 
 		//Filter the Todos by the Projects and Label specified in the Config
 		tasks.items.forEach(function (item) {
-			var isAdded=0; // To prevent a task in added twice. Far from fancy, can be improved. But it works.
-
 			// Ignore sub-tasks
 			if (item.parent_id!=null && !self.config.displaySubtasks) { return; }
 
@@ -270,20 +268,20 @@ Module.register("MMM-Todoist", {
 				// Check all the labels assigned to the task. Add to items if match with configured label
 				for (let label of item.labels) {
 					for (let labelNumber of labelIds) {
-						if (label == labelNumber && isAdded==0) {
+						if (label == labelNumber) {
 							items.push(item);
-							isAdded=1; // Prevent double additions
-							break;
+							return;
 						}
 					}
 				}
 			}
 
 			// Filter using projets if projects are configured
-			if (isAdded==0 && self.config.projects.length>0){
+			if (self.config.projects.length>0){
 			  self.config.projects.forEach(function (project) {
 			  		if (item.project_id == project) {
 						items.push(item);
+						return;
 					}
 			  });
 			}


### PR DESCRIPTION
Currently, the config option displaySubtasks is offered in the documentation but not utilised anywhere within the code.

This PR extends the filtering of tasks to respect this option, and also tidies up the filtering code a little bit.