### PR TITLE
Fix due date parsing

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -460,7 +460,7 @@ Module.register("MMM-Todoist", {
 		var dueDate = new Date(dueDateTime.getFullYear(), dueDateTime.getMonth(), dueDateTime.getDate());
 		var now = new Date();
 		var today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-		var diffDays = Math.floor((dueDate - today + 7200000) / (oneDay));
+		var diffDays = Math.floor((dueDate - today) / (oneDay));
 		var diffMonths = (dueDate.getFullYear() * 12 + dueDate.getMonth()) - (now.getFullYear() * 12 + now.getMonth());
 
 		if (diffDays < -1) {

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -295,11 +295,11 @@ Module.register("MMM-Todoist", {
 				}
 
 				var oneDay = 24 * 60 * 60 * 1000;
-				var dueDateTime = new Date(item.due.date);
+				var dueDateTime = self.parseDueDate(item.due.date);
 				var dueDate = new Date(dueDateTime.getFullYear(), dueDateTime.getMonth(), dueDateTime.getDate());
 				var now = new Date();
 				var today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-				var diffDays = Math.floor((dueDate - today + 7200000) / (oneDay));
+				var diffDays = Math.floor((dueDate - today) / (oneDay));
 				return diffDays <= self.config.displayTasksWithinDays;
 			});
 		}
@@ -387,6 +387,16 @@ Module.register("MMM-Todoist", {
 		};
 
 	},
+	/*
+	 * The Todoist API returns task due dates as strings in these two formats: YYYY-MM-DD and YYYY-MM-DDThh:mm:ss
+	 * This depends on whether a task only has a due day or a due day and time. You cannot pass this date string into
+	 * "new Date()" - it is inconsistent. In one format, the date string is considered to be in UTC, the other in the
+	 * local timezone. The parseDueDate function keeps Dates consistent by keeping them all relative to the local timezone.
+	 */
+	parseDueDate: function (date) {
+		let [year, month, day, hour = 0, minute = 0, second = 0] = date.split(/\D/).map(Number);
+		return new Date(year, month - 1, day, hour, minute, second);
+	},
 	sortByTodoist: function (itemstoSort) {
 		itemstoSort.sort(function (a, b) {
 			// 2019-12-31 bugfix by thyed, property is child_order, not item_order
@@ -450,7 +460,7 @@ Module.register("MMM-Todoist", {
 		var innerHTML = "";
 		
 		var oneDay = 24 * 60 * 60 * 1000;
-		var dueDateTime = new Date(item.due.date);
+		var dueDateTime = this.parseDueDate(item.due.date);
 		var dueDate = new Date(dueDateTime.getFullYear(), dueDateTime.getMonth(), dueDateTime.getDate());
 		var now = new Date();
 		var today = new Date(now.getFullYear(), now.getMonth(), now.getDate());

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -349,8 +349,8 @@ Module.register("MMM-Todoist", {
 				item.due["date"] = "2100-12-31";
 				item.all_day = true;
 			}
-			//Not used right now
-			item.ISOString = new Date(item.due.date);
+			// Used to sort by date.
+			item.date = self.parseDueDate(item.due.date);
 
 			// as v8 API does not have 'all_day' field anymore then check due.date for presence of time
 			// if due.date has a time then set item.all_day to false else all_day is true
@@ -408,17 +408,13 @@ Module.register("MMM-Todoist", {
 	},
 	sortByDueDateAsc: function (itemstoSort) {
 		itemstoSort.sort(function (a, b) {
-			var dateA = new Date(a.ISOString),
-				dateB = new Date(b.ISOString);
-			return dateA - dateB;
+			return a.date - b.date;
 		});
 		return itemstoSort;
 	},
 	sortByDueDateDesc: function (itemstoSort) {
 		itemstoSort.sort(function (a, b) {
-			var dateA = new Date(a.ISOString),
-				dateB = new Date(b.ISOString);
-			return dateB - dateA;
+			return b.date - a.date;
 		});
 		return itemstoSort;
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -39,9 +39,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -102,9 +102,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -200,16 +200,16 @@
       }
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "oauth-sign": {
@@ -223,9 +223,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -265,9 +265,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safer-buffer": {
       "version": "2.1.2",


### PR DESCRIPTION
The Todoist API has two ways of representing due dates:
* "2020-06-15" - If your task only has a due day.
* "2020-06-15T00:00:00" - if your task has a due day and time.

Passing these seemingly equivalent strings into `new Date()` produces two different moments in time.  See [this page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Differences_in_assumed_time_zone) for more info. The end result is that tasks with only due days were relative to UTC and tasks with due days and times were relative to the local timezone. Causing strange ordering and filtering behavior, along with wrong due dates in the display.

This PR fixes this bug by parsing date strings appropriately and keeping them all relative to the local timezone.