### PR TITLE
Don't try and show avatar when it doesn't exist

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -537,7 +537,7 @@ Module.register("MMM-Todoist", {
 		avatarImg.className = "todoAvatarImg";
 
 		var colIndex = collaboratorsMap.get(item.responsible_uid);
-		if (typeof colIndex !== "undefined") {
+		if (typeof colIndex !== "undefined" && this.tasks.collaborators[colIndex].image_id!=null) {
 			avatarImg.src = "https://dcff1xvirvpfp.cloudfront.net/" + this.tasks.collaborators[colIndex].image_id + "_big.jpg";
 		} else { avatarImg.src = "/modules/MMM-Todoist/1x1px.png"; }
 


### PR DESCRIPTION
If a collaborator doesn't have an avatar image set, then currently the module will try and display `https://dcff1xvirvpfp.cloudfront.net/null_big.jpg` as the image, which obviously doesn't exist so shows as a missing image.

This fix checks to see if we have an `image_id` for a collaborator before trying to display it.