### PR TITLE
Change to project name cell

### DIFF
--- a/MMM-Todoist.css
+++ b/MMM-Todoist.css
@@ -37,7 +37,7 @@
 
 .projectcolor {
     padding: 0 !important;
-    margin-left: 4px !important;
+    margin-right: 4px !important;
     display: inline-block;
     width: 12px;
     height: 12px;
@@ -75,6 +75,7 @@
 	/* border: 1px solid #999999; */
 	display: table-cell;
 	/* padding: 3px 10px; */
+	vertical-align: middle;
 }
 .divTableHeading {
 	background-color: #EEE;

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -529,7 +529,7 @@ Module.register("MMM-Todoist", {
 	addProjectCell: function(item) {
 		var project = this.tasks.projects.find(p => p.id === item.project_id);
 		var projectcolor = this.config.projectColors[project.color];
-		var innerHTML = project.name + "<span class='projectcolor' style='color: " + projectcolor + "; background-color: " + projectcolor + "'></span>";
+		var innerHTML = "<span class='projectcolor' style='color: " + projectcolor + "; background-color: " + projectcolor + "'></span>" + project.name;
 		return this.createCell("xsmall", innerHTML);
 	},
 	addAssigneeAvatorCell: function(item, collaboratorsMap) {	


### PR DESCRIPTION
Suggested improvement that I think looks a bit better!

I've moved the project colour indication to before the project name, so everything lines up a bit better. Also switched to `vertical-align: middle` for all cells, which also improves the alignment.