### PR TITLE
Moved access token to header as the new API expects

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -35,10 +35,10 @@ module.exports = NodeHelper.create({
 			method: "POST",
 			headers: {
 				"content-type": "application/x-www-form-urlencoded",
-				"cache-control": "no-cache"
+				"cache-control": "no-cache",
+				"Authorization": "Bearer " + acessCode
 			},
 			form: {
-				token: self.config.accessToken,
 				sync_token: "*",
 				resource_types: self.config.todoistResourceType
 			}


### PR DESCRIPTION
This solves the 403 error returned by the API.

```json
{
    "error":"Invalid CSRF token",
    "error_code":410,
    "error_extra":{"access_type":"web_session","event_id":"private","retry_after":3},
    "error_tag":"AUTH_INVALID_CSRF_TOKEN",
    "http_code":403
}
```

As per new API documentation the access token must be passed in the header (see https://developer.todoist.com/sync/v9/#authorization)

#106 