### PR TITLE
Change CSS class names to avoid conflict with core calendar module

### DIFF
--- a/MMM-Todoist.css
+++ b/MMM-Todoist.css
@@ -23,15 +23,15 @@
     width: 3px;
 }
 
-.overdue {
+.todoDueOverdue {
     text-decoration: underline #ac0000;
 }
 
-.today {
+.todoDueToday {
     text-decoration: underline #03a05c;
 }
 
-.tomorrow {
+.todoDueTomorrow {
     text-decoration: underline #166cec;
 }
 

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -503,20 +503,20 @@ Module.register("MMM-Todoist", {
 			innerHTML = dueDate.toLocaleDateString(config.language, {
 												"month": "short"
 											}) + " " + dueDate.getDate();
-			className += "xsmall overdue";
+			className += "xsmall todoDueOverdue";
 		} else if (diffDays === -1) {
 			innerHTML = this.translate("YESTERDAY");
-			className += "xsmall overdue";
+			className += "xsmall todoDueOverdue";
 		} else if (diffDays === 0) {
 			innerHTML = this.translate("TODAY");
 			if (item.all_day || dueDateTime >= now) {
-				className += "today";
+				className += "todoDueToday";
 			} else {
-				className += "overdue";
+				className += "todoDueOverdue";
 			}
 		} else if (diffDays === 1) {
 			innerHTML = this.translate("TOMORROW");
-			className += "xsmall tomorrow";
+			className += "xsmall todoDueTomorrow";
 		} else if (diffDays < 7) {
 			innerHTML = dueDate.toLocaleDateString(config.language, {
 				"weekday": "short"


### PR DESCRIPTION
Use of the `today` and `tomorrow` CSS class names conflicts with the calendar module included with the core MagicMirror software (see https://github.com/MichMich/MagicMirror/blob/master/modules/default/calendar/calendar.js#L208) since release 2.22.0 (https://github.com/MichMich/MagicMirror/commit/0300ce05d5e7af4584f73115aa590530af0a7655)

This PR changes the class names in use within this module to something less generic to deconflict. 