### PR TITLE
Future yamask patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,15 @@ The following properties can be configured:
 	<tbody>
 		<tr>
 			<td><code>accessToken</code></td>
-			<td>Your Todoist access token, you can get it <a href="https://developer.todoist.com/appconsole.html">here</a>.<br>
+			<td>Your Todoist access token<br>
 				<br><b>Possible values:</b> <code>string</code>
 				<br><b>Default value:</b> <code>none</code>
-				<br><b>Note:</b> It is possible to use the "Test token" and so not to follow the steps of oAuth token. For the web site value requested, you can use "http://example.com" if you don't have a website. 
+				<br><b>Note:</b> You can use one of three values here.
+				<ul>
+					<li>the access token created during the oAuth process associated with your app in the App Management page</li>
+					<li>the "test token" generated in the App Management page withou going through the steps of the oAuth token (For the web site value requested, you can use "http://example.com" if you don't have a website)</li>
+					<li>the "API token" found in your account's Integration settings</li>
+				</ul>
 			</td>
 		</tr>
 		<tr>

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>none</code>
 				<br><b>Note:</b> You can use one of three values here.
 				<ul>
-					<li>the access token created during the oAuth process associated with your app in the App Management page</li>
-					<li>the "test token" generated in the App Management page withou going through the steps of the oAuth token (For the web site value requested, you can use "http://example.com" if you don't have a website)</li>
-					<li>the "API token" found in your account's Integration settings</li>
+					<li>the access token created during the oAuth process associated with your app in the <a href="https://developer.todoist.com/appconsole.html">App Management consol</a></li>
+					<li>the "test token" generated in the <a href="https://developer.todoist.com/appconsole.html">App Management consol</a> without going through the steps of the oAuth token (For the web site value requested, you can use "http://example.com" if you don't have a website)</li>
+					<li>the "API token" found in your account's <a href="https://todoist.com/app/settings/integrations/developer">Integration > Deeloper settings</a></li>
 				</ul>
 			</td>
 		</tr>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following properties can be configured:
 				<ul>
 					<li>the access token created during the oAuth process associated with your app in the <a href="https://developer.todoist.com/appconsole.html">App Management consol</a></li>
 					<li>the "test token" generated in the <a href="https://developer.todoist.com/appconsole.html">App Management consol</a> without going through the steps of the oAuth token (For the web site value requested, you can use "http://example.com" if you don't have a website)</li>
-					<li>the "API token" found in your account's <a href="https://todoist.com/app/settings/integrations/developer">Integration > Deeloper settings</a></li>
+					<li>the "API token" found in your account's <a href="https://todoist.com/app/settings/integrations/developer">Integration > Developer settings</a></li>
 				</ul>
 			</td>
 		</tr>


### PR DESCRIPTION
Adding the ability to use the API token found in your Todoist account settings as an option for accessToken. Rewrote the note about accessToken to clarify the options a bit more. 