### PR TITLE
Fix sortbytodoist and add subtask indenting

### DIFF
--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -414,10 +414,28 @@ Module.register("MMM-Todoist", {
 	},
 	sortByTodoist: function (itemstoSort) {
 		itemstoSort.sort(function (a, b) {
-			// 2019-12-31 bugfix by thyed, property is child_order, not item_order
-			var itemA = a.child_order,
-				itemB = b.child_order;
-			return itemA - itemB;
+			if (!a.parent_id && !b.parent_id) {
+				// neither have parent_id so both are parent tasks, sort by their id
+				return a.id - b.id;
+			} else if (a.parent_id === b.parent_id) {
+				// both are children of the same parent task, sort by child order
+				return a.child_order - b.child_order;
+			} else if (a.parent_id === b.id) {
+				// a is a child of b, so it goes after b
+				return 1;
+			} else if (b.parent_id === a.id) {
+				// b is a child of a, so it goes after a
+				return -1;
+			} else if (!a.parent_id) {
+				// a is a parent task, b is a child (but not of a), so compare a to b's parent
+				return a.id - b.parent_id;
+			} else if (!b.parent_id) {
+				// b is a parent task, a is a child (but not of b), so compare b to a's parent
+				return a.parent_id - b.id;
+			} else {
+				// both are child tasks, but with different parents so sort by their parents
+				return a.parent_id - b.parent_id;
+			}
 		});
 		return itemstoSort;
 	},

--- a/MMM-Todoist.js
+++ b/MMM-Todoist.js
@@ -499,9 +499,14 @@ Module.register("MMM-Todoist", {
 		temp.innerHTML = item.contentHtml;
 
 		var para = temp.getElementsByTagName('p');
-
+		var taskText = para[0].innerHTML;
+		// if sorting by todoist, indent subtasks under their parents
+		if (this.config.sortType === "todoist" && item.parent_id) {
+			// this item is a subtask so indent it
+			taskText = '- ' + taskText;
+		}
 		return this.createCell("title bright alignLeft", 
-			this.shorten(para[0].innerHTML, this.config.maxTitleLength, this.config.wrapEvents));
+			this.shorten(taskText, this.config.maxTitleLength, this.config.wrapEvents));
 
 		// return this.createCell("title bright alignLeft", item.content);
 	},


### PR DESCRIPTION
I found that when you display a project that has parent tasks with subtasks, the sort order appeared to be very random. When I looked into the code I realised that's because it was sorting based on the 'child-order' field only which made no sense i.e. the first child of every task was sorted together, followed by the second child of every task etc.
I've fixed it up so that now it will sort parent tasks based on their id, and child tasks based on their parents id and their child_order i.e. subtasks will now be sorted under their parents as you would expect. 
I also added an indent for the child tasks when sorting this way so it was clearer that they were children of their parent task above.
See the screenshot below for how this looks when you import [Todoists's wedding planner template](https://todoist.com/templates/personal/wedding-planning).
<img width="205" alt="Screen Shot 2023-03-05 at 9 14 43 am" src="https://user-images.githubusercontent.com/36981498/222931007-86e41f90-e3dd-4942-bb6a-f803f6803731.png">
