### PR TITLE
Update doc for Project IDs config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ modules: [
 			updateInterval: 10*60*1000, // Update every 10 minutes
 			fade: false,      
 			// projects and/or labels is mandatory:
-			projects: [ 166564794 ], 
+			projects: [ '7vBnR3cQwY6fM1sP' ], 
 			labels: [ "MagicMirror", "Important" ] // Tasks for any projects with these labels will be shown.
       }
 	}
@@ -80,14 +80,14 @@ The following properties can be configured:
 				Array of ProjectIDs you want to display. <br>
 				<br><b>Possible values:</b> <code>array</code>
 				<br><b>Default value:</b> <code>[ ]</code>
-				<br><b>Example:</b> <code>[166564794, 166564792]</code>
+				<br><b>Example:</b> <code>['7vBnR3cQwY6fM1sP', '2hJdG5tLkV8pN4xZ']</code>
 				<br>
 				<br>
 				<b>Getting the Todoist ProjectID:</b><br>
 				1) Go to Todoist (Log in if you aren't)<br>
 				2) Click on a Project in the left menu<br>
-				3) Your browser URL will change to something like<br> <code>"https://todoist.com/app?lang=en&v=818#project%2F166564897"</code><br><br>
-				Everything after %2F is the Project ID. In this case "166564897"<br><br>
+				3) Your browser URL will change to something like<br> <code>"https://app.todoist.com/app/project/some-name-7vBnR3cQwY6fM1sP"</code><br><br>
+				The Project ID is the part after the last hyphen ("-") in the URL path. In this case "7vBnR3cQwY6fM1sP"<br><br>
 				<hr />
 				Alternatively, if you add <b>debug=true</b> in your config.js the Projects and ProjectsIDs will be displayed on MagicMirror as well as in the Browser console.<br><br>
 				<b>This value and/or the labels entry must be specified</b>. If both projects and labels are specified, then tasks from both will be shown.
@@ -225,7 +225,6 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>false</code>
 			</td>
 		</tr>
-		
 	</tbody>
 </table>
 


### PR DESCRIPTION
## Update documentation for Todoist Project ID format

Todoist has updated its URL structure and project ID format.
This PR updates the README to reflect the current behavior.

Also fIxes (or explains) issue #134 .

Changes:
- Replace legacy numeric project ID examples with the new string-based format (e.g. `7vBnR3cQwY6fM1sP`)
- Update the example URL from the old `todoist.com/app?...#project%2F<id>` format to the current `app.todoist.com/app/project/<name>-<id>` format
- Clarify how to extract the Project ID from the URL: it is the part after the last hyphen (`-`) in the path